### PR TITLE
New option to plsql-spec command to indicate when to capture the output

### DIFF
--- a/lib/plsql/spec/cli.rb
+++ b/lib/plsql/spec/cli.rb
@@ -42,6 +42,10 @@ EOS
           :type => :boolean,
           :default => false,
           :banner => "show DBMS_OUTPUT messages"
+      method_option :capture,
+          :type => :boolean,
+          :default => true,
+          :banner => "hide the output when some exception occur"
       method_option :"html",
           :type => :string,
           :banner => "generate HTML RSpec output to specified file (default is test-results.html)"
@@ -76,10 +80,10 @@ EOS
 
         if files.empty?
           say "Running all specs from spec/", :yellow
-          puts run("#{speccommand} spec", :verbose => false, :capture => true)
+          puts run("#{speccommand} spec", :verbose => false, :capture => options[:capture])
         else
           say "Running specs from #{files.join(', ')}", :yellow
-          puts run("#{speccommand} #{files.join(' ')}", :verbose => false, :capture => true)
+          puts run("#{speccommand} #{files.join(' ')}", :verbose => false, :capture => options[:capture])
         end
 
         if options[:html]


### PR DESCRIPTION
The idea with this commit, is to provide a way to show the output when Thor runs the rspec command, 

In this commit @rsim added the option to Capture the log, and there is no way to disable the option :(
https://github.com/rsim/ruby-plsql-spec/commit/8c76f47fdfec17c1a1a41162b894a5df116b0a5c

The problem with :capture => true is that hide errors that are outside rspec, I ask about this option in the Google Group: 
https://groups.google.com/forum/?fromgroups=#!topic/oracle-enhanced/SmkETvkc2i8

I added a new option "--capture" to "plsql-spec" in order to indicate when do you **don't** want to capture the errors:

``` ruby
    plsql-spec run  --capture=false
```

If you don't provide the capture option, the default value is true (How it works today)

``` ruby
    plsql-spec run
```

In this example I have an error in the test_spec.rb file, I'm requiring a non existing gem

``` ruby
require "spec_helper.rb"
require "non_existing_gem"
```

Before my commit, this is the output
rake probar[ejemplo] executes internally the "plsql-spec" run command

It's very difficult to catch the error
![notes marker](http://i.imgur.com/mFlyHbv.png)

After the commit, with plsql-spec run --capture=false this is the output
![notes marker](http://i.imgur.com/TrkFHyv.png)
