### PR TITLE
Tests: allow fully-qualified svc name connection

### DIFF
--- a/spec/plsql/spec/cli_spec.rb
+++ b/spec/plsql/spec/cli_spec.rb
@@ -24,7 +24,7 @@ describe "plsql-spec" do
     content = "default:\n" <<
     "  username: #{DATABASE_USER}\n" <<
     "  password: #{DATABASE_PASSWORD}\n" <<
-    "  database: #{DATABASE_NAME}\n"
+    "  database: #{DATABASE_SERVICE_NAME}\n"
     content << "  host:     #{DATABASE_HOST}\n" if defined?(DATABASE_HOST)
     content << "  port:     #{DATABASE_PORT}\n" if defined?(DATABASE_PORT)
     File.open(File.join(@root_dir, 'spec/database.yml'), 'w') do |file|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require 'nokogiri'
 require 'ruby-plsql-spec'
 
 DATABASE_NAME = ENV['DATABASE_NAME'] || 'orcl'
+DATABASE_SERVICE_NAME = (defined?(JRUBY_VERSION) ? "/" : "") +
+                        (ENV['DATABASE_SERVICE_NAME'] || DATABASE_NAME)
 DATABASE_HOST = ENV['DATABASE_HOST'] || 'localhost'
 DATABASE_PORT = ENV['DATABASE_PORT'] || 1521
 DATABASE_USER = ENV['DATABASE_USER'] || 'hr'
@@ -18,7 +20,7 @@ DATABASE_PASSWORD = ENV['DATABASE_PASSWORD'] || 'hr'
 CONNECTION_PARAMS = {
   :username => DATABASE_USER,
   :password => DATABASE_PASSWORD,
-  :database => DATABASE_NAME
+  :database => DATABASE_SERVICE_NAME
 }
 CONNECTION_PARAMS[:host] = DATABASE_HOST if defined?(DATABASE_HOST)
 CONNECTION_PARAMS[:port] = DATABASE_PORT if defined?(DATABASE_PORT)


### PR DESCRIPTION
Allow running tests against database with service name is not identical to the the database name.
