### PR TITLE
fix for cli color rendering issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'rspec', '~> 2.0'
+gem 'rspec-support', '~> 3.1'
 gem 'thor', '~> 0.14.2'
 gem 'ruby-plsql', '~> 0.5.0'
 gem 'nokogiri', '~> 1.5.0'

--- a/lib/plsql/spec/cli.rb
+++ b/lib/plsql/spec/cli.rb
@@ -1,5 +1,7 @@
 require 'thor'
 require 'thor/actions'
+require 'rspec/support'
+RSpec::Support.require_rspec_support 'differ'
 
 # use plsql-spec for showing diff of files
 # by defuault Thor uses diff utility which is not available on Windows
@@ -102,7 +104,7 @@ EOS
 
       desc 'diff [FILE1] [FILE2]', 'show difference between files'
       def diff(file1, file2)
-        differ = RSpec::Expectations::Differ.new
+        differ = RSpec::Support::Differ.new
         say differ.diff_as_string File.read(file2), File.read(file1)
       end
 


### PR DESCRIPTION
Use differ from rspec-support to resolve the issue with special characters when rspec is started with color option:

``` ruby
  22) plsql-spec run specified files should report one file examples
     Failure/Error: @stdout.should =~ /1 example/
       expected: /1 example/
            got: "\e[33mRunning specs from spec/test_spec.rb\e[0m\n\n\e[31mFailing tests!\e[0m\n" (using =~)
       Diff:
       @@ -1,2 +1,4 @@
       -/1 example/
       +Running specs from spec/test_spec.rb
       +
       +Failing tests!
```
