### PR TITLE
Updated examples to use the "expect" RSpec syntax.

### DIFF
--- a/examples/spec/award_bonus_spec.rb
+++ b/examples/spec/award_bonus_spec.rb
@@ -16,7 +16,7 @@ describe "Award bonus" do
         :salary => salary
       )
       plsql.award_bonus(employee[:employee_id], sales_amt)
-      get_employee(employee[:employee_id])[:salary].should == result
+      expect(get_employee(employee[:employee_id])[:salary]).to eq result
     end
   end
 

--- a/examples/spec/betwnstr_spec.rb
+++ b/examples/spec/betwnstr_spec.rb
@@ -5,19 +5,19 @@ require "betwnstr"
 
 describe "Between string" do
   it "should be correct in normal case" do
-    plsql.betwnstr('abcdefg', 2, 5).should == 'bcde'
+    expect(plsql.betwnstr('abcdefg', 2, 5)).to eq 'bcde'
   end
 
   it "should be correct with zero start value" do
-    plsql.betwnstr('abcdefg', 0, 5).should == 'abcde'
+    expect(plsql.betwnstr('abcdefg', 0, 5)).to eq 'abcde'
   end
 
   it "should be correct with way big end value" do
-    plsql.betwnstr('abcdefg', 5, 500).should == 'efg'
+    expect(plsql.betwnstr('abcdefg', 5, 500)).to eq 'efg'
   end
 
   it "should be correct with NULL string" do
-    plsql.betwnstr(NULL, 5, 500).should == NULL
+    expect(plsql.betwnstr(NULL, 5, 500)).to eq NULL
   end
 
 end

--- a/examples/spec/oracle_ebs_spec.rb
+++ b/examples/spec/oracle_ebs_spec.rb
@@ -47,11 +47,11 @@ describe "Oracle E-Business Suite" do
       end
 
       it "should return user name" do
-        plsql.fnd_global.user_name.should == @user_name
+        expect(plsql.fnd_global.user_name).to eq @user_name
       end
 
       it "should return responsibility name" do
-        plsql.fnd_global.resp_name.should == @responsibility_name
+        expect(plsql.fnd_global.resp_name).to eq @responsibility_name
       end
 
     end

--- a/examples/spec/remove_rooms_by_name_spec.rb
+++ b/examples/spec/remove_rooms_by_name_spec.rb
@@ -29,7 +29,7 @@ describe "Remove rooms by name" do
   it "should remove a room without furniture" do
     rooms_without_b = plsql.rooms.all("WHERE name NOT LIKE 'B%'")
     plsql.remove_rooms_by_name('B%')
-    plsql.rooms.all.should == rooms_without_b
+    expect(plsql.rooms.all).to eq rooms_without_b
   end
 
   it "should not remove a room with furniture" do


### PR DESCRIPTION
The examples were using deprecated `.should` syntax
This pull request is to address that.