### PR TITLE
Release 0.5.0

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,10 +1,17 @@
-==
+== 0.5.0 2016-05-13
 
 * Improvements
-  * Support for higher ruby-plsql version ruby-plsql (e.g. the latest one: 0.6)
-
+  * Tested with ruby 2.3.0, 2.3.1
+  * Support for higher ruby-plsql versions - 0.6+ (#38)
+  * `require 'spec_helper'` is no longer needed in each spec file (#26)
+  * Update examples to use the "expect" RSpec syntax (#23)
+* Bug fixes
+  * Fix profiler: was only working with UPCASE procedure and function name (#30)
+  * Fix disposal of connections when using multiple ones (#22)
 * Internal (development) improvements
-  * Migrate from jeweler to juwelier
+  * Migrate from jeweler to juwelier (#37)
+  * Setup CI build on travis-ci.org (#36)
+  * Allow reporting of Unit Tests on Jenkins CI with "RspecJunitFormatter" (#31)
 
 == 0.4.0 2015-01-30
 

--- a/ruby-plsql-spec.gemspec
+++ b/ruby-plsql-spec.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Raimonds Simanovskis".freeze]
-  s.date = "2016-05-11"
+  s.date = "2016-05-13"
   s.description = "ruby-plsql-spec is Oracle PL/SQL unit testing framework which is built using Ruby programming language, ruby-plsql library and RSpec testing framework.\n".freeze
   s.email = "raimonds.simanovskis@gmail.com".freeze
   s.executables = ["plsql-spec".freeze]


### PR DESCRIPTION
== 0.5.0 2016-05-13

* Improvements
  * Tested with ruby 2.3.0, 2.3.1
  * Support for higher ruby-plsql versions - 0.6+ (#38)
  * `require 'spec_helper'` is no longer needed in each spec file (#26)
  * Update examples to use the `expect` RSpec syntax (#23)
* Bug fixes
  * Fix profiler: was only working with` UPCASE` procedure and function name (#30)
  * Fix disposal of connections when using multiple ones (#22)
* Internal (development) improvements
  * Migrate from jeweler to juwelier (#37)
  * Setup CI build on travis-ci.org (#36)
  * Allow reporting of Unit Tests on Jenkins CI with "RspecJunitFormatter" (#31)