### PR TITLE
The link to "Ruby Installer for Windows" is broken

### DIFF
--- a/INSTALL-Windows.md
+++ b/INSTALL-Windows.md
@@ -6,7 +6,7 @@ Ruby installation on Windows is a little bit different than installation on Mac 
 Install Ruby
 ------------
 
-Download and install Ruby from [Ruby Installer for Windows](http://www.rubyinstaller.org/).
+Download and install Ruby from [Ruby Installer for Windows](https://rubyinstaller.org/).
 
 When installing then select checkbox to add Ruby to your PATH.
 


### PR DESCRIPTION
The link to "Ruby Installer for Windows" took me to a 'app doesn't exist' page on Heroku. https://rubyinstaller.org/ appears to be the correct link.